### PR TITLE
chore: remove copyright comments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-# Copyright (c) Brandon Pacewic
-# SPDX-License-Identifier: MIT
-
 * @BrandonPacewic

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Copyright (c) Brandon Pacewic
-# SPDX-License-Identifier: MIT
-
 build/
 dist/
 __pycache__/


### PR DESCRIPTION
The remaining python comments will be removed once the rust rewrite is finished and all leftover python code is removed.