### PR TITLE
feat(shell): utilize shell printing for accurate verbosity logging

### DIFF
--- a/src/commands/dbrun.rs
+++ b/src/commands/dbrun.rs
@@ -16,7 +16,7 @@ pub fn command() -> Command {
         )
 }
 
-pub fn exec(_gctx: &mut GlobalContext, args: &ArgMatches) {
+pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) {
     let file = match args.get_one::<String>("file") {
         Some(val) => val.clone(),
         None => {
@@ -31,7 +31,7 @@ pub fn exec(_gctx: &mut GlobalContext, args: &ArgMatches) {
     };
 
     if !Path::new(&file).exists() {
-        eprintln!("{} file not found.", file);
+        gctx.shell().error(format!("{} file not found.", file));
         return;
     }
 
@@ -49,8 +49,10 @@ pub fn exec(_gctx: &mut GlobalContext, args: &ArgMatches) {
     }
 
     let duration = start_time.elapsed();
-    println!("Successfully compiled in {:?}", duration);
-    println!("--------------------");
+    gctx.shell().note(format!(
+        "Successfully compiled in {}s\n--------------------",
+        duration.as_secs_f32()
+    ));
 
     let _ = ProcessCommand::new("./a.out")
         .status()

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -51,10 +51,16 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) {
         let output = command.output();
         if let Ok(output) = output {
             if !output.status.success() {
-                eprintln!("Error formatting file: {:?}", file);
+                gctx.shell().error(format!(
+                    "Failed to format file: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
             }
         } else {
-            eprintln!("Failed to execute clang-format for file: {:?}", file);
+            gctx.shell().error(format!(
+                "Failed to execute clang-format for file: {}",
+                file.display()
+            ));
         }
     }
 
@@ -90,8 +96,11 @@ fn get_clang_format_config(gctx: &mut GlobalContext, args: &ArgMatches) -> Optio
         .map(|(path, _)| path.to_string_lossy().into_owned());
 
     if config_file.is_none() {
-        println!("No config file found for {}", config);
-        print!("Defaulting to no config");
+        gctx.shell().warn(format!(
+            "No config file found for {}. Available configs: {:?}",
+            config, config_names
+        ));
+        return None;
     }
 
     config_file

--- a/src/commands/gen.rs
+++ b/src/commands/gen.rs
@@ -63,7 +63,8 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) {
         .collect();
 
     if expanded_paths.is_empty() {
-        println!("No templates found for the given file(s) / directory(s)");
+        gctx.shell()
+            .warn("No templates found for the given file(s) / directory(s)");
         return;
     }
 
@@ -71,9 +72,13 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) {
         let file_name = path.split('/').last().unwrap();
         let dest_path = format!("{}/{}", gctx.cwd().to_string_lossy(), file_name);
         if fs::copy(&path, &dest_path).is_err() {
-            println!("Failed to copy template file to destination: {}", dest_path);
+            gctx.shell().error(format!(
+                "Failed to copy template file ({}) destination {}",
+                path, dest_path
+            ));
         } else {
-            println!("Generated template file: {}", file_name);
+            gctx.shell()
+                .note(format!("Generated template file: {}", file_name));
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -99,6 +99,14 @@ impl Shell {
         self.print(Some(&message));
     }
 
+    pub fn warn<T: fmt::Display>(&mut self, message: T) {
+        self.print(Some(&message));
+    }
+
+    pub fn error<T: fmt::Display>(&mut self, message: T) {
+        self.print(Some(&message));
+    }
+
     pub fn set_verbosity(&mut self, verbosity: Verbosity) {
         self.verbosity = verbosity;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ mod version;
 
 fn main() {
     let args = branp().try_get_matches().unwrap();
-    let (expanded_args, global_args) = expand_aliases(args, vec![]).unwrap();
     let mut gctx = match GlobalContext::default() {
         Some(gctx) => gctx,
         None => {
@@ -20,6 +19,7 @@ fn main() {
         }
     };
 
+    let (expanded_args, global_args) = expand_aliases(&mut gctx, args, vec![]).unwrap();
     let is_verbose = expanded_args.get_count("verbose") > 0;
 
     if expanded_args.get_flag("version") {
@@ -92,6 +92,7 @@ impl GlobalArgs {
 }
 
 fn expand_aliases(
+    gctx: &mut GlobalContext,
     args: ArgMatches,
     mut already_expanded: Vec<String>,
 ) -> Option<(ArgMatches, GlobalArgs)> {
@@ -102,10 +103,10 @@ fn expand_aliases(
         match (exec, aliased_cmd) {
             (Some(_), Some(_)) => {
                 // User alias conflicts with built-in subcommand.
-                println!(
+                gctx.shell().warn(format!(
                     "user-defined alias `{}` is ignored as it conflicts with a built-in subcommand",
                     cmd
-                );
+                ));
             }
             (Some(_), None) => {} // Found a subcommand with no overlapping alias, do nothing.
             // Not a subcommand and not an alias, an error but not for the responsibility of this function.
@@ -139,7 +140,7 @@ fn expand_aliases(
                     panic!("subcommand alias `{}` is recursive", cmd);
                 }
 
-                let (expanded_args, _) = expand_aliases(new_args, already_expanded)?;
+                let (expanded_args, _) = expand_aliases(gctx, new_args, already_expanded)?;
                 return Some((expanded_args, global_args));
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,8 @@ impl Exec {
         if let Some(exec) = commands::branp_exec(cmd) {
             Self::Branp(exec)
         } else {
+            // Until branp supports colored logging and exiting outside of simply halting the program
+            // this will be left here. Once status printing is improved this will be removed.
             color_print::cprintln!(
                 "<red,bold>error</>: <yellow>{}</> is not a valid subcommand",
                 cmd


### PR DESCRIPTION
- **feat(shell): convert all relevant print statements to `context.shell`**
- **docs(shell): add comment justifiying remaining print statment**
