### PR TITLE
chore(ci): change workflow running conditions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,8 @@
 name: Rust Linting
 on:
-  push:
-    paths:
-      - '**/*.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
   pull_request:
-    paths:
-      - '**/*.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
+    branches:
+      - mega
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changed linting ci to only run on prs into `mega` not on push or in any other pr. Additionally the workflow will run even if no rust code was changed. This is what github expects as its a required check for all prs going into `mega`.